### PR TITLE
Fix issue with duplicate class names when REST-API is used in SOS bundle

### DIFF
--- a/mappings/src/main/hbm/sos/v44/FeatureParameter.hbm.xml
+++ b/mappings/src/main/hbm/sos/v44/FeatureParameter.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="org.n52.series.db.beans.parameter">
-    <class name="FeatureParameter" table="featureparameter">
+    <class name="FeatureParameter" table="featureparameter" entity-name="RestFeatureParameter">
         <id name="parameterId" type="long">
             <column name="parameterid"/>
             <generator class="assigned"/>

--- a/mappings/src/main/hbm/sos/v44/FeatureResource.hbm.xml
+++ b/mappings/src/main/hbm/sos/v44/FeatureResource.hbm.xml
@@ -29,7 +29,7 @@
 
     <set inverse="true" name="parameters" table="featureparameter">
         <key column="featureofinterestid" not-null="true"/>
-        <one-to-many class="org.n52.series.db.beans.parameter.FeatureParameter"/>
+        <one-to-many class="org.n52.series.db.beans.parameter.FeatureParameter" entity-name="RestFeatureParameter"/>
     </set>
   </class>
 </hibernate-mapping>


### PR DESCRIPTION
In the SOS and in the REST-API the parameter class for features have the same name "FeatureParameter" that occurs an Hiberante issue. Fixed by using entity-name and response still contains feature parameter values.