### PR TITLE
Fix/parameter conflict on expanded services

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
@@ -201,7 +201,9 @@ public class ServiceRepository extends ParameterRepository<ServiceEntity, Servic
         try {
             ParameterCount quantities = new ServiceOutput.ParameterCount();
             DbQuery serviceQuery = getDbQuery(query.getParameters()
-                                                   .extendWith(IoParameters.SERVICES, service.getId()));
+                                                   .extendWith(IoParameters.SERVICES, service.getId())
+                                                   .removeAllOf("offset")
+                                                   .removeAllOf("limit"));
             quantities.setOfferingsSize(counter.countOfferings(serviceQuery));
             quantities.setProceduresSize(counter.countProcedures(serviceQuery));
             quantities.setCategoriesSize(counter.countCategories(serviceQuery));

--- a/dao/src/main/java/org/n52/series/db/dao/DbQuery.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DbQuery.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
+import org.hibernate.criterion.Order;
 
 public class DbQuery {
 
@@ -255,9 +256,11 @@ public class DbQuery {
     Criteria addLimitAndOffsetFilter(Criteria criteria) {
         if (getParameters().containsParameter(Parameters.OFFSET)) {
             criteria.setFirstResult(getParameters().getOffset());
+            criteria.addOrder(Order.asc(PROPERTY_PKID));
         }
         if (getParameters().containsParameter(Parameters.LIMIT)) {
             criteria.setMaxResults(getParameters().getLimit());
+            criteria.addOrder(Order.asc(PROPERTY_PKID));
         }
         return criteria;
     }

--- a/dao/src/main/java/org/n52/series/db/dao/DbQuery.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DbQuery.java
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
-import org.hibernate.criterion.Order;
 
 public class DbQuery {
 
@@ -256,11 +255,9 @@ public class DbQuery {
     Criteria addLimitAndOffsetFilter(Criteria criteria) {
         if (getParameters().containsParameter(Parameters.OFFSET)) {
             criteria.setFirstResult(getParameters().getOffset());
-            criteria.addOrder(Order.asc(PROPERTY_PKID));
         }
         if (getParameters().containsParameter(Parameters.LIMIT)) {
             criteria.setMaxResults(getParameters().getLimit());
-            criteria.addOrder(Order.asc(PROPERTY_PKID));
         }
         return criteria;
     }


### PR DESCRIPTION
Fixes Error when using `limit` or `offset` together with `expanded=true` on `/services` Endpoint. 

Further Explanation of error cause in commit message.

Error was first reported by @ridoo in https://github.com/52North/series-rest-api/pull/386 