### PR TITLE
Improve last geometry query

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
@@ -87,7 +87,7 @@ public abstract class AbstractDataRepository<D extends Data< ? >,
     @Override
     public GeometryEntity getLastValueGeometry(S entity, Session session, DbQuery query) {
         DataDao<E> dao = createDataDao(session);
-        return dao.getGeometryValueViaTimeend(entity, query);
+        return dao.getValueGeometryViaTimeend(entity, query);
     }
 
     protected DatasetDao<S> getSeriesDao(Session session) {

--- a/dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
@@ -84,6 +84,12 @@ public abstract class AbstractDataRepository<D extends Data< ? >,
         return createSeriesValueFor(valueEntity, entity, query);
     }
 
+    @Override
+    public GeometryEntity getLastValueGeometry(S entity, Session session, DbQuery query) {
+        DataDao<E> dao = createDataDao(session);
+        return dao.getGeometryValueViaTimeend(entity, query);
+    }
+
     protected DatasetDao<S> getSeriesDao(Session session) {
         return new DatasetDao<>(session);
     }

--- a/dao/src/main/java/org/n52/series/db/da/DataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/DataRepository.java
@@ -35,6 +35,7 @@ import org.n52.io.response.dataset.Data;
 import org.n52.series.db.DataAccessException;
 import org.n52.series.db.HibernateSessionStore;
 import org.n52.series.db.beans.DatasetEntity;
+import org.n52.series.db.beans.GeometryEntity;
 import org.n52.series.db.beans.ServiceEntity;
 import org.n52.series.db.dao.DbQuery;
 
@@ -45,6 +46,8 @@ public interface DataRepository<E extends DatasetEntity< ? >, V extends Abstract
     V getFirstValue(E entity, Session session, DbQuery query);
 
     V getLastValue(E entity, Session session, DbQuery query);
+
+    GeometryEntity getLastValueGeometry(E lastDataset, Session session, DbQuery query);
 
     void setSessionStore(HibernateSessionStore sessionStore);
 

--- a/dao/src/main/java/org/n52/series/db/dao/DataDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DataDao.java
@@ -191,7 +191,7 @@ public class DataDao<T extends DataEntity> extends AbstractDao<T> {
 
     @SuppressWarnings("unchecked")
     private T getDataValueAt(Date timestamp, String column, DatasetEntity series, DbQuery query) {
-        Criteria criteria = createDataAtCriteria(timestamp, COLUMN_TIMESTART, series, query);
+        Criteria criteria = createDataAtCriteria(timestamp, column, series, query);
 
         IoParameters parameters = query.getParameters();
         if (parameters.containsParameter(Parameters.RESULTTIME)) {


### PR DESCRIPTION
This improves the platform geometry query from observations.
On a dataset from the NeXOS demo server the querying of the latest profile geometry was improved from ~28 s to ~200 ms.