### PR TITLE
Improve (om:)parameter handling

### DIFF
--- a/dao/src/main/java/org/n52/series/db/beans/DataEntity.java
+++ b/dao/src/main/java/org/n52/series/db/beans/DataEntity.java
@@ -73,7 +73,7 @@ public abstract class DataEntity<T> {
 
     private boolean child;
 
-    private final Set<Parameter< ? >> parameters = new HashSet<>(0);
+    private Set<Parameter> parameters = new HashSet<>(0);
 
     public Long getPkid() {
         return pkid;
@@ -234,13 +234,16 @@ public abstract class DataEntity<T> {
         this.child = child;
     }
 
-    public Set<Parameter< ? >> getParameters() {
+    public Set<Parameter> getParameters() {
         return parameters;
     }
 
-    public void setParameters(Set<Parameter< ? >> parameters) {
-        if (parameters != null) {
-            this.parameters.addAll(parameters);
+    @SuppressWarnings(value = "unchecked")
+    public void setParameters(Object parameters) {
+        if (parameters instanceof Set<?>) {
+            this.parameters = (Set<Parameter>) parameters;
+        } else {
+            getParameters().add((Parameter) parameters);
         }
     }
 

--- a/mappings/src/main/hbm/sos/v44/DataResource.hbm.xml
+++ b/mappings/src/main/hbm/sos/v44/DataResource.hbm.xml
@@ -22,7 +22,7 @@
             -->
             <property column="samplingGeometry" name="geometry" type="org.hibernate.spatial.GeometryType"/>
         </component>
-        <set inverse="true" name="parameters" table="parameter">
+        <set inverse="true" name="parameters" table="parameter" fetch="join">
             <key column="observationid" not-null="true"/>
             <one-to-many class="org.n52.series.db.beans.parameter.ObservationParameter"/>
         </set>


### PR DESCRIPTION
Use join instead of select and fix setter in DataEntity for parameter join.
If the parameter fetch mode is not `join`, for each observation/data a new `SELECT`-query is executed.