### PR TITLE
consider actual time column when projecting oldest resulttime

### DIFF
--- a/dao/src/main/java/org/n52/series/db/dao/DataDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DataDao.java
@@ -215,8 +215,9 @@ public class DataDao<T extends DataEntity> extends AbstractDao<T> {
                 COLUMN_SERIES_PKID,
                 COLUMN_RESULTTIME
             }, maxResultTimeQuery));
-            
-        }return criteria;
-}
+
+        }
+        return criteria;
+    }
 
 }


### PR DESCRIPTION
uses SQL query projection to match only oldest `resultTime` when querying data values