### PR TITLE
Align QuantityProfileDataRepository behaviour with other DataRepositories.

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/QuantityProfileDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/QuantityProfileDataRepository.java
@@ -87,6 +87,10 @@ public class QuantityProfileDataRepository
     protected ProfileValue<Double> createSeriesValueFor(ProfileDataEntity valueEntity,
                                                 ProfileDatasetEntity datasetEntity,
                                                 DbQuery query) {
+        if (valueEntity == null) {
+            // do not fail on empty observations
+            return null;
+        }
         Date timeend = valueEntity.getPhenomenonTimeEnd();
         Date timestart = valueEntity.getPhenomenonTimeStart();
         long end = timeend.getTime();


### PR DESCRIPTION
Fixed NPE in handling of empty observations in QuantityProfileDataRepository.

Aligns QPDR behaviour with other DataRepositories - Examples:

https://github.com/52North/dao-series-api/blob/08d071f43edefa48003b2f2f3eeeb02f5cac838b/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java#L154

https://github.com/52North/dao-series-api/blob/08d071f43edefa48003b2f2f3eeeb02f5cac838b/dao/src/main/java/org/n52/series/db/da/RecordDataRepository.java#L148

https://github.com/52North/dao-series-api/blob/08d071f43edefa48003b2f2f3eeeb02f5cac838b/dao/src/main/java/org/n52/series/db/da/CountDataRepository.java#L145
