### PR TITLE
Fix/v3.x/fix dataset counter mismatch

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
@@ -65,7 +65,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author <a href="mailto:h.bredel@52north.org">Henning Bredel</a>
  * @param <T>
- *        the dataset's type this repository is responsible for.
+ *        the datasets type this repository is responsible for.
  */
 public class DatasetRepository<T extends Data> extends SessionAwareRepository
         implements OutputAssembler<DatasetOutput> {
@@ -140,7 +140,9 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
                                      Session session)
             throws DataAccessException {
         for (DatasetEntity series : dao.getAllInstances(query)) {
-            results.add(createCondensed(series, query, session));
+            if (dataRepositoryFactory.isKnown(series.getValueType())) {            
+                results.add(createCondensed(series, query, session));
+            }
         }
     }
 
@@ -213,7 +215,9 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
                                     Session session)
             throws DataAccessException {
         for (DatasetEntity series : dao.getAllInstances(query)) {
-            results.add(createExpanded(series, query, session));
+            if (dataRepositoryFactory.isKnown(series.getValueType())) {
+                results.add(createExpanded(series, query, session));
+            }
         }
     }
 

--- a/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
+++ b/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
@@ -124,8 +124,7 @@ public class EntityCounter {
                         "valueTypes",
                         dataRepositoryFactory.getKnownTypes().toArray(new String[0])
                 );
-                DbQuery newQuery = dbQueryFactory.createFrom(parameters);
-                return getCount(new DatasetDao<>(session, DatasetEntity.class), newQuery);
+                query = dbQueryFactory.createFrom(parameters);
             }
             return getCount(new DatasetDao<>(session, DatasetEntity.class), query);
         } finally {

--- a/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
+++ b/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
@@ -124,7 +124,8 @@ public class EntityCounter {
                         "valueTypes",
                         dataRepositoryFactory.getKnownTypes().toArray(new String[0])
                 );
-                query = dbQueryFactory.createFrom(parameters);
+                return getCount(new DatasetDao<>(session, DatasetEntity.class),
+                                dbQueryFactory.createFrom(parameters));
             }
             return getCount(new DatasetDao<>(session, DatasetEntity.class), query);
         } finally {

--- a/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
+++ b/dao/src/main/java/org/n52/series/db/da/EntityCounter.java
@@ -58,6 +58,9 @@ public class EntityCounter {
     @Autowired
     private DbQueryFactory dbQueryFactory;
 
+    @Autowired
+    private IDataRepositoryFactory dataRepositoryFactory;
+
     public Integer countFeatures(DbQuery query) throws DataAccessException {
         Session session = sessionStore.getSession();
         try {
@@ -115,7 +118,16 @@ public class EntityCounter {
     public Integer countDatasets(DbQuery query) throws DataAccessException {
         Session session = sessionStore.getSession();
         try {
-            return getCount(new DatasetDao<DatasetEntity>(session, DatasetEntity.class), query);
+            IoParameters parameters = query.getParameters();
+            if (parameters.getValueTypes().isEmpty()) {
+                parameters = parameters.extendWith(
+                        "valueTypes",
+                        dataRepositoryFactory.getKnownTypes().toArray(new String[0])
+                );
+                DbQuery newQuery = dbQueryFactory.createFrom(parameters);
+                return getCount(new DatasetDao<>(session, DatasetEntity.class), newQuery);
+            }
+            return getCount(new DatasetDao<>(session, DatasetEntity.class), query);
         } finally {
             sessionStore.returnSession(session);
         }

--- a/dao/src/main/java/org/n52/series/db/da/IDataRepositoryFactory.java
+++ b/dao/src/main/java/org/n52/series/db/da/IDataRepositoryFactory.java
@@ -29,11 +29,14 @@
 
 package org.n52.series.db.da;
 
+import java.util.Set;
 import org.n52.io.DatasetFactoryException;
 
 public interface IDataRepositoryFactory {
 
     boolean isKnown(String valueType);
+
+    Set<String> getKnownTypes();
 
     DataRepository create(String valueType) throws DatasetFactoryException;
 


### PR DESCRIPTION
Fixes mismatch in Counter described in #86. 

By default the Query Parameter `valueType` is now set to all implemented valueTypes. The User can overwrite this setting by specifying a `valueType` in the Query-Parameters.