### PR TITLE
Implementation of `services` Query-Parameter

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
@@ -139,7 +139,8 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
                                      List<DatasetOutput> results,
                                      Session session)
             throws DataAccessException {
-        for (DatasetEntity series : dao.getAllInstances(query)) {
+        Iterable<? extends DatasetEntity> entities = addServiceFilter(dao.getAllInstances(query), query);
+        for (DatasetEntity series : entities) {
             results.add(createCondensed(series, query, session));
         }
     }
@@ -212,7 +213,8 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
                                     List<DatasetOutput> results,
                                     Session session)
             throws DataAccessException {
-        for (DatasetEntity series : dao.getAllInstances(query)) {
+        Iterable<? extends DatasetEntity> entities = addServiceFilter(dao.getAllInstances(query), query);
+        for (DatasetEntity series : entities) {
             results.add(createExpanded(series, query, session));
         }
     }

--- a/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
@@ -190,7 +190,7 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
     private FeatureEntity getFeatureEntity(String id, DbQuery parameters, Session session) throws DataAccessException {
         FeatureDao dao = createFeatureDao(session);
         long geometryId = Long.parseLong(GeometryType.extractId(id));
-        return addServiceFilter(dao.getInstance(geometryId, parameters), parameters);
+        return dao.getInstance(geometryId, parameters);
     }
 
     private List<GeometryInfo> getAllSites(DbQuery parameters, Session session, boolean expanded)
@@ -200,8 +200,7 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
         DbQuery siteQuery = dbQueryFactory.createFrom(parameters.getParameters()
                                                                 .replaceWith(Parameters.FILTER_PLATFORM_TYPES,
                                                                              "stationary"));
-        Iterable<FeatureEntity> entities = addServiceFilter(dao.getAllInstances(siteQuery), parameters);
-        for (FeatureEntity featureEntity : entities) {
+        for (FeatureEntity featureEntity : dao.getAllInstances(siteQuery)) {
             GeometryInfo geometryInfo = createSite(featureEntity, parameters, expanded);
             if (geometryInfo != null) {
                 geometryInfoList.add(geometryInfo);
@@ -225,8 +224,7 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
         DbQuery trackQuery = dbQueryFactory.createFrom(parameters.getParameters()
                                                                  .replaceWith(Parameters.FILTER_PLATFORM_TYPES,
                                                                               "mobile"));
-        List<FeatureEntity> entities = addServiceFilter(featureDao.getAllInstances(trackQuery), parameters);
-        for (FeatureEntity featureEntity : entities) {
+        for (FeatureEntity featureEntity : featureDao.getAllInstances(trackQuery)) {
             geometryInfoList.add(createTrack(featureEntity, parameters, expanded, session));
         }
         return geometryInfoList;
@@ -337,9 +335,7 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
                                                                     .extendWith(Parameters.FEATURES,
                                                                                 String.valueOf(entity.getPkid()))
                                                                     .extendWith(Parameters.FILTER_PLATFORM_TYPES,
-                                                                                "all")
-                                                                    .removeAllOf(Parameters.SERVICES)
-                                                                    .removeAllOf(Parameters.SERVICE));
+                                                                                "all"));
         List<PlatformOutput> platforms = platformRepository.getAllCondensed(platformQuery);
         return platforms.iterator()
                         .next();

--- a/dao/src/main/java/org/n52/series/db/da/HierarchicalParameterRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/HierarchicalParameterRepository.java
@@ -46,7 +46,8 @@ public abstract class HierarchicalParameterRepository<E extends HierarchicalEnti
     @Override
     protected List<O> createExpanded(Iterable<E> entities, DbQuery query, Session session) throws DataAccessException {
         Set<O> results = new HashSet<>();
-        if (entities != null) {
+        if (entities != null && entities.iterator().hasNext()) {
+            addServiceFilter(entities, query);
             for (E entity : entities) {
                 O result = createExpanded(entity, query, session);
                 results.add(result);
@@ -58,7 +59,8 @@ public abstract class HierarchicalParameterRepository<E extends HierarchicalEnti
     @Override
     protected List<O> createCondensed(Iterable<E> entities, DbQuery query, Session session) {
         Set<O> results = new HashSet<>();
-        if (entities != null) {
+        if (entities != null && entities.iterator().hasNext()) {
+            addServiceFilter(entities, query);
             for (E entity : entities) {
                 O result = createCondensed(entity, query, session);
                 results.add(result);

--- a/dao/src/main/java/org/n52/series/db/da/ParameterRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/ParameterRepository.java
@@ -88,7 +88,14 @@ public abstract class ParameterRepository<E extends DescribableEntity, O extends
 
     protected List<O> createCondensed(Iterable<E> allInstances, DbQuery query, Session session) {
         List<O> results = new ArrayList<>();
-        for (E entity : allInstances) {
+        Iterable<E> entities = addServiceFilter(allInstances, query);
+        for (E entity : entities) {
+            /*
+             *  there are cases where entity does not match a filter
+             *  which could not be added to a db criteria, e.g. spatial
+             *  filters on mobile platforms (last location is calculated
+             *  after db query has been finished already)
+             */
             results.add(createCondensed(entity, query, session));
         }
         return results;
@@ -131,11 +138,12 @@ public abstract class ParameterRepository<E extends DescribableEntity, O extends
     protected List<O> createExpanded(Iterable<E> allInstances, DbQuery query, Session session)
             throws DataAccessException {
         List<O> results = new ArrayList<>();
-        for (E entity : allInstances) {
+        Iterable<E> entities = addServiceFilter(allInstances, query);
+        for (E entity : entities) {
             O instance = createExpanded(entity, query, session);
             if (instance != null) {
                 /*
-                 *  there are cases where entities does not match a filter
+                 *  there are cases where entity does not match a filter
                  *  which could not be added to a db criteria, e.g. spatial
                  *  filters on mobile platforms (last location is calculated
                  *  after db query has been finished already)

--- a/dao/src/main/java/org/n52/series/db/da/PlatformRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/PlatformRepository.java
@@ -153,9 +153,9 @@ public class PlatformRepository extends ParameterRepository<PlatformEntity, Plat
 
     PlatformEntity getEntity(String id, DbQuery parameters, Session session) throws DataAccessException {
         if (PlatformType.isStationaryId(id)) {
-            return getStation(id, parameters, session);
+            return addServiceFilter(getStation(id, parameters, session), parameters);
         } else {
-            return getPlatform(id, parameters, session);
+            return addServiceFilter(getPlatform(id, parameters, session), parameters);
         }
     }
 
@@ -266,10 +266,10 @@ public class PlatformRepository extends ParameterRepository<PlatformEntity, Plat
         List<PlatformEntity> platforms = new ArrayList<>();
         FilterResolver filterResolver = query.getFilterResolver();
         if (filterResolver.shallIncludeStationaryPlatformTypes()) {
-            platforms.addAll(getAllStationary(query, session));
+            platforms.addAll(addServiceFilter(getAllStationary(query, session), query));
         }
         if (filterResolver.shallIncludeMobilePlatformTypes()) {
-            platforms.addAll(getAllMobile(query, session));
+            platforms.addAll(addServiceFilter(getAllMobile(query, session), query));
         }
         return platforms;
     }

--- a/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
@@ -29,8 +29,9 @@
 
 package org.n52.series.db.da;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,7 @@ public class ServiceRepository extends ParameterRepository<ServiceEntity, Servic
     @Override
     protected List<ServiceEntity> getAllInstances(DbQuery parameters, Session session) throws DataAccessException {
         return serviceEntity != null
-                ? Collections.singletonList(serviceEntity)
+                ? new ArrayList<ServiceEntity>(Arrays.asList(serviceEntity))
                 : createDao(session).getAllInstances(parameters);
     }
 
@@ -148,6 +149,7 @@ public class ServiceRepository extends ParameterRepository<ServiceEntity, Servic
         ServiceEntity result = !isConfiguredServiceInstance(id)
                 ? dao.getInstance(id, query)
                 : serviceEntity;
+        addServiceFilter(result, query);
         if (result == null) {
             throw new ResourceNotFoundException("Resource with id '" + id + "' could not be found.");
         }

--- a/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/ServiceRepository.java
@@ -29,9 +29,8 @@
 
 package org.n52.series.db.da;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +138,7 @@ public class ServiceRepository extends ParameterRepository<ServiceEntity, Servic
     @Override
     protected List<ServiceEntity> getAllInstances(DbQuery parameters, Session session) throws DataAccessException {
         return serviceEntity != null
-                ? new ArrayList<ServiceEntity>(Arrays.asList(serviceEntity))
+                ? Collections.singletonList(serviceEntity)
                 : createDao(session).getAllInstances(parameters);
     }
 
@@ -149,7 +148,6 @@ public class ServiceRepository extends ParameterRepository<ServiceEntity, Servic
         ServiceEntity result = !isConfiguredServiceInstance(id)
                 ? dao.getInstance(id, query)
                 : serviceEntity;
-        addServiceFilter(result, query);
         if (result == null) {
             throw new ResourceNotFoundException("Resource with id '" + id + "' could not be found.");
         }

--- a/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
@@ -310,7 +310,11 @@ public abstract class SessionAwareRepository {
                 !query.getParameters()
                       .getServices()
                       .contains(Long.toString(getServiceEntity(element).getPkid()))) {
-                iterator.remove();
+                try {
+                    iterator.remove();
+                } catch (UnsupportedOperationException e) {
+                    // dao returning immutable list does not want serviceFilter to be added
+                }
             }
         }
         return allInstances;

--- a/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
@@ -32,7 +32,7 @@ package org.n52.series.db.da;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.Iterator;
 
 import org.hibernate.Session;
 import org.n52.io.crs.CRSUtils;
@@ -297,16 +297,22 @@ public abstract class SessionAwareRepository {
         }
     }
 
-    protected <T extends DescribableEntity> List<T> withServiceFilter(List<T> allInstances, DbQuery query) {
-        Predicate<T> serviceFilter =
-            entity -> !query.getParameters().getServices().isEmpty() &&
-                      !query.getParameters().getServices()
-                            .contains(Long.toString(getServiceEntity(entity).getPkid()));
-        allInstances.removeIf(serviceFilter);
+    protected <T extends DescribableEntity, V extends Iterable<T>> V addServiceFilter(V allInstances, DbQuery query) {
+        Iterator iterator = allInstances.iterator();
+        while (iterator.hasNext()) {
+            T element = (T) iterator.next();
+            if (!query.getParameters().getServices().isEmpty() &&
+                !query.getParameters()
+                      .getServices()
+                      .contains(Long.toString(getServiceEntity(element)
+                      .getPkid()))) {
+                iterator.remove();
+            }
+        }
         return allInstances;
     }
-    
-    protected <T extends DescribableEntity> T withServiceFilter(T instance, DbQuery query) {
+
+    protected <T extends DescribableEntity> T addServiceFilter(T instance, DbQuery query) {
         if (!query.getParameters().getServices().isEmpty() &&
             !query.getParameters().getServices()
                   .contains(Long.toString(getServiceEntity(instance).getPkid()))) {

--- a/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
@@ -309,8 +309,7 @@ public abstract class SessionAwareRepository {
             if (!query.getParameters().getServices().isEmpty() &&
                 !query.getParameters()
                       .getServices()
-                      .contains(Long.toString(getServiceEntity(element)
-                      .getPkid()))) {
+                      .contains(Long.toString(getServiceEntity(element).getPkid()))) {
                 iterator.remove();
             }
         }

--- a/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
@@ -32,6 +32,7 @@ package org.n52.series.db.da;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.hibernate.Session;
 import org.n52.io.crs.CRSUtils;
@@ -296,4 +297,22 @@ public abstract class SessionAwareRepository {
         }
     }
 
+    protected <T extends DescribableEntity> List<T> withServiceFilter(List<T> allInstances, DbQuery query) {
+        Predicate<T> serviceFilter =
+            entity -> !query.getParameters().getServices().isEmpty() &&
+                      !query.getParameters().getServices()
+                            .contains(Long.toString(getServiceEntity(entity).getPkid()));
+        allInstances.removeIf(serviceFilter);
+        return allInstances;
+    }
+    
+    protected <T extends DescribableEntity> T withServiceFilter(T instance, DbQuery query) {
+        if (!query.getParameters().getServices().isEmpty() &&
+            !query.getParameters().getServices()
+                  .contains(Long.toString(getServiceEntity(instance).getPkid()))) {
+            return null;
+        } else {
+            return instance;
+        }
+    }
 }

--- a/dao/src/main/java/org/n52/series/db/da/StationRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/StationRepository.java
@@ -81,7 +81,7 @@ public class StationRepository extends SessionAwareRepository
         try {
             FeatureDao stationDao = createDao(session);
             DbQuery query = addPointLocationOnlyRestriction(getDbQuery(parameters));
-            List<FeatureEntity> found = stationDao.find(query);
+            List<FeatureEntity> found = withServiceFilter(stationDao.find(query), query);
             return convertToSearchResults(found, query);
         } finally {
             returnSession(session);
@@ -142,7 +142,7 @@ public class StationRepository extends SessionAwareRepository
 
     private List<FeatureEntity> getAllInstances(DbQuery parameters, Session session) throws DataAccessException {
         FeatureDao featureDao = createDao(session);
-        return featureDao.getAllInstances(addPointLocationOnlyRestriction(parameters));
+        return withServiceFilter(featureDao.getAllInstances(addPointLocationOnlyRestriction(parameters)), parameters);
     }
 
     @Override
@@ -167,13 +167,16 @@ public class StationRepository extends SessionAwareRepository
     private FeatureEntity getFeatureEntity(String id, DbQuery parameters, Session session)
             throws DataAccessException, BadRequestException {
         DbQuery query = addPointLocationOnlyRestriction(parameters);
-        return createDao(session).getInstance(parseId(id), query);
+        return withServiceFilter(createDao(session).getInstance(parseId(id), query), parameters);
     }
 
     public StationOutput getCondensedInstance(String id, DbQuery parameters, Session session)
             throws DataAccessException {
         FeatureDao featureDao = createDao(session);
-        FeatureEntity result = featureDao.getInstance(parseId(id), getDbQuery(IoParameters.createDefaults()));
+        FeatureEntity result = withServiceFilter(
+                featureDao.getInstance(parseId(id), getDbQuery(IoParameters.createDefaults())),
+                parameters
+        );
         return createCondensed(result, parameters);
     }
 

--- a/dao/src/main/java/org/n52/series/db/da/StationRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/StationRepository.java
@@ -81,7 +81,7 @@ public class StationRepository extends SessionAwareRepository
         try {
             FeatureDao stationDao = createDao(session);
             DbQuery query = addPointLocationOnlyRestriction(getDbQuery(parameters));
-            List<FeatureEntity> found = withServiceFilter(stationDao.find(query), query);
+            List<FeatureEntity> found = addServiceFilter(stationDao.find(query), query);
             return convertToSearchResults(found, query);
         } finally {
             returnSession(session);
@@ -142,7 +142,7 @@ public class StationRepository extends SessionAwareRepository
 
     private List<FeatureEntity> getAllInstances(DbQuery parameters, Session session) throws DataAccessException {
         FeatureDao featureDao = createDao(session);
-        return withServiceFilter(featureDao.getAllInstances(addPointLocationOnlyRestriction(parameters)), parameters);
+        return addServiceFilter(featureDao.getAllInstances(addPointLocationOnlyRestriction(parameters)), parameters);
     }
 
     @Override
@@ -167,13 +167,13 @@ public class StationRepository extends SessionAwareRepository
     private FeatureEntity getFeatureEntity(String id, DbQuery parameters, Session session)
             throws DataAccessException, BadRequestException {
         DbQuery query = addPointLocationOnlyRestriction(parameters);
-        return withServiceFilter(createDao(session).getInstance(parseId(id), query), parameters);
+        return addServiceFilter(createDao(session).getInstance(parseId(id), query), parameters);
     }
 
     public StationOutput getCondensedInstance(String id, DbQuery parameters, Session session)
             throws DataAccessException {
         FeatureDao featureDao = createDao(session);
-        FeatureEntity result = withServiceFilter(
+        FeatureEntity result = addServiceFilter(
                 featureDao.getInstance(parseId(id), getDbQuery(IoParameters.createDefaults())),
                 parameters
         );

--- a/dao/src/main/java/org/n52/series/db/da/TimeseriesRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/TimeseriesRepository.java
@@ -137,7 +137,8 @@ public class TimeseriesRepository extends SessionAwareRepository implements Outp
     public List<TimeseriesMetadataOutput> getAllCondensed(DbQuery query, Session session) throws DataAccessException {
         List<TimeseriesMetadataOutput> results = new ArrayList<>();
         DatasetDao<QuantityDatasetEntity> seriesDao = createDao(session);
-        for (QuantityDatasetEntity timeseries : seriesDao.getAllInstances(query)) {
+        Iterable<QuantityDatasetEntity> entities = addServiceFilter(seriesDao.getAllInstances(query), query);
+        for (QuantityDatasetEntity timeseries : entities) {
             results.add(createCondensed(timeseries, query, session));
         }
         return results;
@@ -157,7 +158,8 @@ public class TimeseriesRepository extends SessionAwareRepository implements Outp
     public List<TimeseriesMetadataOutput> getAllExpanded(DbQuery query, Session session) throws DataAccessException {
         List<TimeseriesMetadataOutput> results = new ArrayList<>();
         DatasetDao<QuantityDatasetEntity> seriesDao = createDao(session);
-        for (QuantityDatasetEntity timeseries : seriesDao.getAllInstances(query)) {
+        Iterable<QuantityDatasetEntity> entities = addServiceFilter(seriesDao.getAllInstances(query), query);
+        for (QuantityDatasetEntity timeseries : entities) {
             results.add(createExpanded(timeseries, query, session));
         }
         return results;
@@ -174,14 +176,14 @@ public class TimeseriesRepository extends SessionAwareRepository implements Outp
     }
 
     @Override
-    public TimeseriesMetadataOutput getInstance(String timeseriesId, DbQuery dbQuery, Session session)
+    public TimeseriesMetadataOutput getInstance(String timeseriesId, DbQuery query, Session session)
             throws DataAccessException {
         DatasetDao<QuantityDatasetEntity> seriesDao = createDao(session);
-        QuantityDatasetEntity result = seriesDao.getInstance(parseId(timeseriesId), dbQuery);
+        QuantityDatasetEntity result = addServiceFilter(seriesDao.getInstance(parseId(timeseriesId), query), query);
         if (result == null) {
             throw new ResourceNotFoundException("Resource with id '" + timeseriesId + "' could not be found.");
         }
-        return createExpanded(result, dbQuery, session);
+        return createExpanded(result, query, session);
     }
 
     protected TimeseriesMetadataOutput createExpanded(QuantityDatasetEntity series, DbQuery query, Session session)


### PR DESCRIPTION
This implements the Query Parameter on all Endpoints described in Issue #92.

As the service entity might not be mapped by hibernate but be injected by spring the filtering can not be done in Hibernate, and must be done after the results were retrieved from the database (only then is it certain that entities have the correct associated service entity.)