### PR TITLE
V3.x/fix/reference values

### DIFF
--- a/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/DatasetRepository.java
@@ -309,8 +309,7 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
 
             DataRepository dataRepository = dataRepositoryFactory.create(dataset.getValueType());
             AbstractValue firstValue = dataRepository.getFirstValue(dataset, session, query);
-            AbstractValue lastValue = dataset.getFirstValueAt().equals(dataset.getLastValueAt()) ? firstValue
-                    : dataRepository.getLastValue(dataset, session, query);
+            AbstractValue lastValue = dataRepository.getLastValue(dataset, session, query);
 
             List<ReferenceValueOutput> refValues = dataRepository.createReferenceValueOutputs(dataset, query);
             lastValue = isReferenceSeries(dataset) && isCongruentValues(firstValue, lastValue)
@@ -331,7 +330,9 @@ public class DatasetRepository<T extends Data> extends SessionAwareRepository
     }
 
     private boolean isCongruentValues(AbstractValue<?> firstValue, AbstractValue<?> lastValue) {
-        return firstValue.getTimestamp().equals(lastValue.getTimestamp());
+        return firstValue == null && lastValue == null
+                || firstValue != null && lastValue.getTimestamp().equals(firstValue.getTimestamp())
+                || lastValue != null && firstValue.getTimestamp().equals(lastValue.getTimestamp());
     }
 
     private boolean isReferenceSeries(DatasetEntity series) {

--- a/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
@@ -353,6 +353,9 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
                                                      .extendWith(Parameters.FEATURES, String.valueOf(entity.getId()))
                                                      .extendWith(Parameters.FILTER_PLATFORM_TYPES, "all"));
         List<PlatformOutput> platforms = platformRepository.getAllCondensed(platformQuery);
+        if (platforms.size() != 1) {
+            LOGGER.warn("expected unique platform (but was: #{}) for feature {}", platforms.size(), entity.getId()); 
+        }
         return platforms.iterator()
                         .next();
     }

--- a/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/GeometriesRepository.java
@@ -354,7 +354,7 @@ public class GeometriesRepository extends SessionAwareRepository implements Outp
                                                      .extendWith(Parameters.FILTER_PLATFORM_TYPES, "all"));
         List<PlatformOutput> platforms = platformRepository.getAllCondensed(platformQuery);
         if (platforms.size() != 1) {
-            LOGGER.warn("expected unique platform (but was: #{}) for feature {}", platforms.size(), entity.getId()); 
+            LOGGER.warn("expected unique platform (but was: #{}) for feature {}", platforms.size(), entity.getId());
         }
         return platforms.iterator()
                         .next();

--- a/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
@@ -31,6 +31,7 @@ package org.n52.series.db.da;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,8 +40,10 @@ import org.hibernate.Session;
 import org.n52.io.response.dataset.Data;
 import org.n52.io.response.dataset.DatasetMetadata;
 import org.n52.io.response.dataset.DatasetOutput;
+import org.n52.io.response.dataset.ReferenceValueOutput;
 import org.n52.io.response.dataset.quantity.QuantityValue;
 import org.n52.series.db.DataAccessException;
+import org.n52.series.db.beans.ProcedureEntity;
 import org.n52.series.db.beans.QuantityDataEntity;
 import org.n52.series.db.beans.QuantityDatasetEntity;
 import org.n52.series.db.beans.ServiceEntity;
@@ -53,6 +56,24 @@ public class QuantityDataRepository extends
     @Override
     public Class<QuantityDatasetEntity> getDatasetEntityType() {
         return QuantityDatasetEntity.class;
+    }
+
+    @Override
+    public List<ReferenceValueOutput<QuantityValue>> createReferenceValueOutputs(QuantityDatasetEntity datasetEntity,
+                                                                                 DbQuery query) {
+        List<QuantityDatasetEntity> referenceValues = datasetEntity.getReferenceValues();
+        List<ReferenceValueOutput<QuantityValue>> outputs = new ArrayList<>();
+        for (QuantityDatasetEntity referenceSeriesEntity : referenceValues) {
+            ReferenceValueOutput<QuantityValue> refenceValueOutput = new ReferenceValueOutput<>();
+            ProcedureEntity procedure = referenceSeriesEntity.getProcedure();
+            refenceValueOutput.setLabel(procedure.getNameI18n(query.getLocale()));
+            refenceValueOutput.setReferenceValueId(createReferenceDatasetId(query, referenceSeriesEntity));
+
+            QuantityDataEntity lastValue = (QuantityDataEntity) referenceSeriesEntity.getLastObservation();
+            refenceValueOutput.setLastValue(createSeriesValueFor(lastValue, referenceSeriesEntity, query));
+            outputs.add(refenceValueOutput);
+        }
+        return outputs;
     }
 
     @Override

--- a/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
@@ -75,9 +75,8 @@ public class QuantityDataRepository extends
             throws DataAccessException {
         Map<String, Data<QuantityValue>> referenceSeries = new HashMap<>();
         for (QuantityDatasetEntity referenceSeriesEntity : referenceValues) {
-            if (referenceSeriesEntity.isPublished() && referenceValues instanceof QuantityDatasetEntity) {
-                Data<QuantityValue> referenceSeriesData =
-                        assembleData(referenceSeriesEntity, query, session);
+            if (referenceSeriesEntity.isPublished() && referenceSeriesEntity instanceof QuantityDatasetEntity) {
+                Data<QuantityValue> referenceSeriesData = assembleData(referenceSeriesEntity, query, session);
                 if (haveToExpandReferenceData(referenceSeriesData)) {
                     referenceSeriesData = expandReferenceDataIfNecessary(referenceSeriesEntity,
                                                                          query,

--- a/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
@@ -115,7 +115,7 @@ public class QuantityDataRepository extends
         DatasetOutput< ? > dataset = DatasetOutput.create(valueType, query.getParameters());
         Long id = referenceSeriesEntity.getId();
         dataset.setId(id.toString());
-        
+
         String referenceDatasetId = dataset.getId();
         return referenceDatasetId.toString();
     }

--- a/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
+++ b/dao/src/main/java/org/n52/series/db/da/QuantityDataRepository.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import org.hibernate.Session;
 import org.n52.io.response.dataset.Data;
 import org.n52.io.response.dataset.DatasetMetadata;
+import org.n52.io.response.dataset.DatasetOutput;
 import org.n52.io.response.dataset.quantity.QuantityValue;
 import org.n52.series.db.DataAccessException;
 import org.n52.series.db.beans.QuantityDataEntity;
@@ -82,12 +83,20 @@ public class QuantityDataRepository extends
                                                                          query,
                                                                          session);
                 }
-                referenceSeries.put(referenceSeriesEntity.getId()
-                                                         .toString(),
-                                    referenceSeriesData);
+                referenceSeries.put(createReferenceDatasetId(query, referenceSeriesEntity), referenceSeriesData);
             }
         }
         return referenceSeries;
+    }
+
+    protected String createReferenceDatasetId(DbQuery query, QuantityDatasetEntity referenceSeriesEntity) {
+        String valueType = referenceSeriesEntity.getValueType();
+        DatasetOutput< ? > dataset = DatasetOutput.create(valueType, query.getParameters());
+        Long id = referenceSeriesEntity.getId();
+        dataset.setId(id.toString());
+        
+        String referenceDatasetId = dataset.getId();
+        return referenceDatasetId.toString();
     }
 
     private boolean haveToExpandReferenceData(Data<QuantityValue> referenceSeriesData) {

--- a/dao/src/main/java/org/n52/series/db/dao/AbstractDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/AbstractDao.java
@@ -121,10 +121,10 @@ public abstract class AbstractDao<T> implements GenericDao<T, Long> {
     }
 
     protected T getInstance(String key, DbQuery query, Class<T> clazz, Criteria criteria) {
-        criteria = query.isMatchDomainIds()
+        Criteria instanceCriteria = query.isMatchDomainIds()
                 ? criteria.add(Restrictions.eq(DescribableEntity.PROPERTY_DOMAIN_ID, key))
                 : criteria.add(Restrictions.eq(DescribableEntity.PROPERTY_ID, Long.parseLong(key)));
-        return clazz.cast(criteria.uniqueResult());
+        return clazz.cast(instanceCriteria.uniqueResult());
     }
 
     @Override

--- a/dao/src/main/java/org/n52/series/db/dao/AbstractDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/AbstractDao.java
@@ -114,9 +114,13 @@ public abstract class AbstractDao<T> implements GenericDao<T, Long> {
         return getInstance(Long.toString(key), query, getEntityClass());
     }
 
-    private T getInstance(String key, DbQuery query, Class<T> clazz) {
+    protected T getInstance(String key, DbQuery query, Class<T> clazz) {
         LOGGER.debug("get instance for '{}'. {}", key, query);
         Criteria criteria = getDefaultCriteria(query, clazz);
+        return getInstance(key, query, clazz, criteria);
+    }
+
+    protected T getInstance(String key, DbQuery query, Class<T> clazz, Criteria criteria) {
         criteria = query.isMatchDomainIds()
                 ? criteria.add(Restrictions.eq(DescribableEntity.PROPERTY_DOMAIN_ID, key))
                 : criteria.add(Restrictions.eq(DescribableEntity.PROPERTY_ID, Long.parseLong(key)));

--- a/dao/src/main/java/org/n52/series/db/dao/DatasetDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DatasetDao.java
@@ -105,6 +105,11 @@ public class DatasetDao<T extends DatasetEntity> extends AbstractDao<T> implemen
     }
 
     @Override
+    protected T getInstance(String key, DbQuery query, Class<T> clazz) {
+        return super.getInstance(key, query, clazz, getDefaultCriteria(null, false, query, clazz));
+    }
+    
+    @Override
     @SuppressWarnings("unchecked")
     public List<T> getAllInstances(DbQuery query) throws DataAccessException {
         LOGGER.debug("get all instances: {}", query);

--- a/dao/src/main/java/org/n52/series/db/dao/DatasetDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/DatasetDao.java
@@ -108,7 +108,7 @@ public class DatasetDao<T extends DatasetEntity> extends AbstractDao<T> implemen
     protected T getInstance(String key, DbQuery query, Class<T> clazz) {
         return super.getInstance(key, query, clazz, getDefaultCriteria(null, false, query, clazz));
     }
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public List<T> getAllInstances(DbQuery query) throws DataAccessException {

--- a/dao/src/main/java/org/n52/series/db/dao/FeatureDao.java
+++ b/dao/src/main/java/org/n52/series/db/dao/FeatureDao.java
@@ -26,6 +26,7 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
+
 package org.n52.series.db.dao;
 
 import org.hibernate.Session;

--- a/tests/example-data.sql
+++ b/tests/example-data.sql
@@ -110,6 +110,7 @@ COPY procedure (procedure_id, fk_format_id, identifier, fk_identifier_codespace_
 7	3	http://www.52north.org/test/procedure/7	\N	ITC	\N	\N	0	\N	0	\N	0	0	1
 8	3	http://www.52north.org/test/procedure/8	\N	DLZ-IT	\N	\N	0	\N	0	\N	0	1	1
 9	3	http://www.52north.org/test/procedure/developer	\N	http://www.52north.org/test/procedure/developer	\N	\N	0	\N	0	\N	0	0	1
+10	3	http://www.52north.org/test/procedure/reference	\N	http://www.52north.org/test/procedure/reference	\N	\N	0	\N	1	\N	0	1	1
 \.
 
 
@@ -138,6 +139,13 @@ COPY dataset (dataset_id, fk_feature_id, fk_category_id, fk_phenomenon_id, fk_pr
 10	11	9	9	9	8	9	0	0	0	2008-10-29 00:00:00	2008-10-29 00:00:00	\N	\N	\N	\N	\N	\N	text	\N
 11	12	9	9	9	8	9	0	1	0	2008-10-29 00:00:00	2008-10-29 00:00:00	\N	\N	\N	\N	\N	\N	text	\N
 12	13	9	9	9	8	9	0	1	0	2012-12-31 23:00:00	2012-12-31 23:00:00	\N	\N	\N	\N	\N	\N	text	\N
+13	9	8	8	10	4	8	0	1	0	2012-11-19 13:00:00	2012-11-19 13:49:59	5	\N	\N	\N	\N	\N	quantity	3
+\.
+
+
+
+COPY dataset_reference (fk_dataset_id_from, sort_order, fk_dataset_id_to) FROM stdin;
+8	0	13
 \.
 
 
@@ -251,6 +259,7 @@ update dataset set fk_first_observation_id=81,fk_last_observation_id=81 where da
 update dataset set fk_first_observation_id=82,fk_last_observation_id=82 where dataset_id=10;
 update dataset set fk_first_observation_id=83,fk_last_observation_id=83 where dataset_id=11;
 update dataset set fk_first_observation_id=84,fk_last_observation_id=84 where dataset_id=12;
+update dataset set fk_first_observation_id=71,fk_last_observation_id=100,first_value=4.0,last_value=5.9 where dataset_id=13;
 
 
 

--- a/tests/sos-example-data.postman_collection.json
+++ b/tests/sos-example-data.postman_collection.json
@@ -16,7 +16,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1fba8bab-05f6-4df0-bbcb-afed5d1e1ea2",
+								"id": "f96f8b30-7da7-4894-a6eb-879df7efa99b",
 								"type": "text/javascript",
 								"exec": [
 									"// https://github.com/postmanlabs/postman-app-support/issues/882#issuecomment-278759032",
@@ -68,9 +68,9 @@
 									"                                                    || logFailWarning(\"Content-Type\", contentType, actualContentType);",
 									"    };",
 									"",
-									"    helpers.containsId = function(data, id) {",
+									"    helpers.containsId = function(data, id, idName=\"id\") {",
 									"        for (var i = 0; i < data.length ; i++) {",
-									"            if (data[i] && data[i].id === id) {",
+									"            if (data[i] && data[i][idName] === id) {",
 									"                return true;",
 									"            }",
 									"        }",
@@ -191,7 +191,7 @@
 						"header": [],
 						"body": {},
 						"url": {
-							"raw": "http://{{host}}:{{port}}{{context}}/api/",
+							"raw": "http://{{host}}:{{port}}{{context}}/api/services",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -199,7 +199,7 @@
 							"port": "{{port}}{{context}}",
 							"path": [
 								"api",
-								""
+								"services"
 							]
 						},
 						"description": ""
@@ -1746,6 +1746,7 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "632cf2e1-c8ec-4e1c-b471-b5bfcd2a8da7",
 								"type": "text/javascript",
 								"exec": [
 									"var helpers = eval(globals.loadHelpers);",
@@ -1758,6 +1759,7 @@
 									"helpers.testAllMembersPresent(jsonData, [\"id\", \"href\", \"uom\", \"label\", \"platformType\"]);",
 									"",
 									"tests[\"Deleted Dataset text_5 is not listed\"] = !helpers.containsId(jsonData, \"text_5\");",
+									"tests[\"Reference Dataset quantity_13 is not listed\"] = !helpers.containsId(jsonData, \"quantity_13\");",
 									"tests[\"Unpublished Dataset quantity_10 is not listed\"] = !helpers.containsId(jsonData, \"quantity_10\");"
 								]
 							}
@@ -1780,7 +1782,7 @@
 							"raw": "{\r\n  \"legend\": true,\r\n  \"timespan\": \"P0Y0M3D/2013-01-31TZ\",\r\n  \"width\": 400,\r\n  \"height\": 300,\r\n  \"language\": \"de\",\r\n  \"grid\": true,\r\n  \"styleOptions\": {\r\n    \"328\": {\r\n      \"chartType\": \"line\",\r\n      \"properties\": {\r\n        \"color\": \"#0000FF\",\r\n        \"lineType\": \"solid\",\r\n        \"width\": 1\r\n      }\r\n    },\r\n    \"159\": {\r\n      \"chartType\": \"bar\",\r\n      \"properties\": {\r\n        \"color\": \"#2f2f2f\",\r\n        \"interval\": \"byHour\",\r\n        \"width\": 0.7\r\n      }\r\n    }\r\n  }\r\n}"
 						},
 						"url": {
-							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets",
+							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets/",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -1788,7 +1790,8 @@
 							"port": "{{port}}{{context}}",
 							"path": [
 								"api",
-								"datasets"
+								"datasets",
+								""
 							]
 						},
 						"description": ""
@@ -1801,7 +1804,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d96ccbdd-3375-4b7d-9889-122a40b25d8d",
+								"id": "851890ef-fff3-45a4-a820-4579e5af73b9",
 								"type": "text/javascript",
 								"exec": [
 									"var helpers = eval(globals.loadHelpers);",
@@ -1814,6 +1817,11 @@
 									"",
 									"tests[\"item has correct id\"] = jsonData.id === \"quantity_8\";",
 									"tests[\"item has correct valueType\"] = jsonData.valueType === \"quantity\";",
+									"",
+									"var refValues = jsonData.referenceValues;",
+									"tests[\"item has reference values listed\"] = refValues !== undefined;",
+									"tests[\"item lists reference value quantity_13\"] = refValues !== undefined && helpers.containsId(refValues, \"quantity_13\", \"referenceValueId\");",
+									"",
 									"tests[\"item has first value\"] = jsonData.firstValue !== undefined;",
 									"tests[\"first value has geometry\"] = jsonData.firstValue.geometry !== undefined;",
 									"tests[\"first value is POINT(7 50)\"] = jsonData.firstValue.geometry.coordinates[0] == 7 && jsonData.firstValue.geometry.coordinates[1] == 50;",
@@ -1845,7 +1853,7 @@
 							"raw": "{\r\n  \"legend\": true,\r\n  \"timespan\": \"P0Y0M3D/2013-01-31TZ\",\r\n  \"width\": 400,\r\n  \"height\": 300,\r\n  \"language\": \"de\",\r\n  \"grid\": true,\r\n  \"styleOptions\": {\r\n    \"328\": {\r\n      \"chartType\": \"line\",\r\n      \"properties\": {\r\n        \"color\": \"#0000FF\",\r\n        \"lineType\": \"solid\",\r\n        \"width\": 1\r\n      }\r\n    },\r\n    \"159\": {\r\n      \"chartType\": \"bar\",\r\n      \"properties\": {\r\n        \"color\": \"#2f2f2f\",\r\n        \"interval\": \"byHour\",\r\n        \"width\": 0.7\r\n      }\r\n    }\r\n  }\r\n}"
 						},
 						"url": {
-							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets/quantity_8",
+							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets/quantity_8?expanded=true",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -1855,6 +1863,13 @@
 								"api",
 								"datasets",
 								"quantity_8"
+							],
+							"query": [
+								{
+									"key": "expanded",
+									"value": "true",
+									"equals": true
+								}
 							]
 						},
 						"description": ""
@@ -2059,6 +2074,59 @@
 								"datasets",
 								"quantity-profile_1",
 								""
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "GET reference dataset",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c7c561a5-0e42-4248-9577-4dbeac274328",
+								"type": "text/javascript",
+								"exec": [
+									"var helpers = eval(globals.loadHelpers);",
+									"",
+									"helpers.test200();",
+									"helpers.testContentTypeStartsWith(\"application/json\");",
+									"var jsonData = JSON.parse(responseBody);",
+									"",
+									"helpers.testAllMembersPresent(jsonData, [\"id\", \"href\", \"uom\", \"label\", \"platformType\"]);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"legend\": true,\r\n  \"timespan\": \"P0Y0M3D/2013-01-31TZ\",\r\n  \"width\": 400,\r\n  \"height\": 300,\r\n  \"language\": \"de\",\r\n  \"grid\": true,\r\n  \"styleOptions\": {\r\n    \"328\": {\r\n      \"chartType\": \"line\",\r\n      \"properties\": {\r\n        \"color\": \"#0000FF\",\r\n        \"lineType\": \"solid\",\r\n        \"width\": 1\r\n      }\r\n    },\r\n    \"159\": {\r\n      \"chartType\": \"bar\",\r\n      \"properties\": {\r\n        \"color\": \"#2f2f2f\",\r\n        \"interval\": \"byHour\",\r\n        \"width\": 0.7\r\n      }\r\n    }\r\n  }\r\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets/quantity_13",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}{{context}}",
+							"path": [
+								"api",
+								"datasets",
+								"quantity_13"
 							]
 						},
 						"description": ""
@@ -3553,6 +3621,77 @@
 								{
 									"key": "timespan",
 									"value": "P1D/2012-11-20TZ",
+									"equals": true
+								}
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "GET mobile data (quantity_8) w/ reference values",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c67e4e31-d6f2-4d67-8312-423dc9424398",
+								"type": "text/javascript",
+								"exec": [
+									"var helpers = eval(globals.loadHelpers);",
+									"",
+									"helpers.test200();",
+									"helpers.testContentTypeStartsWith(\"application/json\");",
+									"",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"values are qualified\"] = jsonData.quantity_8 !== undefined;",
+									"",
+									"var extra = jsonData.quantity_8.extra;",
+									"tests[\"reference values are serialized\"] = extra !== undefined && extra.referenceValues !== undefined;",
+									"tests[\"reference dataset quantity_13 is listed\"] = extra.referenceValues && extra.referenceValues.quantity_13 !== undefined;",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"legend\": true,\r\n  \"timespan\": \"P0Y0M3D/2013-01-31TZ\",\r\n  \"width\": 400,\r\n  \"height\": 300,\r\n  \"language\": \"de\",\r\n  \"grid\": true,\r\n  \"styleOptions\": {\r\n    \"328\": {\r\n      \"chartType\": \"line\",\r\n      \"properties\": {\r\n        \"color\": \"#0000FF\",\r\n        \"lineType\": \"solid\",\r\n        \"width\": 1\r\n      }\r\n    },\r\n    \"159\": {\r\n      \"chartType\": \"bar\",\r\n      \"properties\": {\r\n        \"color\": \"#2f2f2f\",\r\n        \"interval\": \"byHour\",\r\n        \"width\": 0.7\r\n      }\r\n    }\r\n  }\r\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}{{context}}/api/datasets/quantity_8/data?timespan=P200D/2012-11-20TZ&expanded=true",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}{{context}}",
+							"path": [
+								"api",
+								"datasets",
+								"quantity_8",
+								"data"
+							],
+							"query": [
+								{
+									"key": "timespan",
+									"value": "P200D/2012-11-20TZ",
+									"equals": true
+								},
+								{
+									"key": "expanded",
+									"value": "true",
 									"equals": true
 								}
 							]


### PR DESCRIPTION
reference values were not handled appropriately (currently only quantity value types supports reference values). The fix includes
* setting the qualified id
* lists reference datasets in `/datasets/<id>` (with `expanded=true`)
* lists reference values in `/datasets/<id>/data` (with `expanded=true`)
* reference datasets aren't listed in `/datasets/` but are accessible via `/datasets/<id>` individually to obtain metadata